### PR TITLE
add ToList() to prevent collection modification during iteration

### DIFF
--- a/Network/Client/ClientSync.cs
+++ b/Network/Client/ClientSync.cs
@@ -264,22 +264,22 @@ namespace AMP.Network.Client {
             threadCancel.Cancel();
             StopAllCoroutines();
 
-            foreach(PlayerNetworkData ps in syncData.players.Values) {
+            foreach(PlayerNetworkData ps in syncData.players.Values.ToList()) {
                 LeavePlayer(ps);
             }
 
-            foreach(ItemNetworkData ind in syncData.items.Values    ) {
+            foreach(ItemNetworkData ind in syncData.items.Values.ToList()) {
                 if(ind.networkItem != null) {
                     Destroy(ind.networkItem);
                 }
             }
-            foreach(CreatureNetworkData cnd in syncData.creatures.Values) {
+            foreach(CreatureNetworkData cnd in syncData.creatures.Values.ToList()) {
                 if(cnd.networkCreature != null) {
                     cnd.SetOwnership(true);
                     Destroy(cnd.networkCreature);
                 }
             }
-            foreach(PlayerNetworkData pnd in syncData.players.Values) {
+            foreach(PlayerNetworkData pnd in syncData.players.Values.ToList()) {
                 if(pnd.networkCreature != null) {
                     if(pnd.creature != null) {
                         pnd.isSpawning = true; // To prevent the player from respawning
@@ -410,7 +410,7 @@ namespace AMP.Network.Client {
         }
 
         private IEnumerator TryRespawningPlayers() {
-            foreach(PlayerNetworkData pnd in syncData.players.Values) {
+            foreach(PlayerNetworkData pnd in syncData.players.Values.ToList()) {
                 if(  (pnd.creature == null ||/* !pnd.creature.enabled ||*/ !pnd.creature.loaded || !pnd.creature.isCulled)
                   && !pnd.isSpawning
                   && pnd.receivedPos
@@ -420,7 +420,7 @@ namespace AMP.Network.Client {
                         Spawner.TrySpawnPlayer(pnd);
                     });
 
-                    yield return new WaitForSeconds(Config.LONG_WAIT_DEALY);
+                    yield return new WaitForSeconds(Config.LONG_WAIT_DELAY);
                 }
             }
         }
@@ -509,7 +509,7 @@ namespace AMP.Network.Client {
         }
 
         internal void SendMovedCreatures() {
-            foreach(CreatureNetworkData cnd in syncData.creatures.Values) {
+            foreach(CreatureNetworkData cnd in syncData.creatures.Values.ToList()) {
                 if(!ModManager.clientInstance.allowTransmission) continue;
                 if(cnd.networkCreature == null) continue;
                 if(cnd.networkedId <= 0) continue;
@@ -527,7 +527,7 @@ namespace AMP.Network.Client {
         }
 
         internal void SendMovedEntities() {
-            foreach(EntityNetworkData end in syncData.entities.Values) {
+            foreach(EntityNetworkData end in syncData.entities.Values.ToList()) {
                 if(!ModManager.clientInstance.allowTransmission) continue;
                 if(end.networkEntity == null) continue;
                 if(end.entity == null) continue;
@@ -609,10 +609,10 @@ namespace AMP.Network.Client {
             Color[] colors = new Color[0];
             CreatureEquipment.Read(creature, ref colors, ref wardrobe);
 
-            foreach(CreatureNetworkData cs in ModManager.clientSync.syncData.creatures.Values) {
+            foreach(CreatureNetworkData cs in ModManager.clientSync.syncData.creatures.Values.ToList()) {
                 if(cs.creature == creature) yield break; // If creature already exists, just exit
             }
-            foreach(PlayerNetworkData playerSync in ModManager.clientSync.syncData.players.Values) {
+            foreach(PlayerNetworkData playerSync in ModManager.clientSync.syncData.players.Values.ToList()) {
                 if(playerSync.creature == creature) yield break;
             }
             if(Player.currentCreature != null && Player.currentCreature == creature) yield break;
@@ -723,7 +723,7 @@ namespace AMP.Network.Client {
         }
 
         internal static void EquipItemsForCreature(int id, ItemHolderType holderType) {
-            foreach(ItemNetworkData ind in ModManager.clientSync.syncData.items.Values) {
+            foreach(ItemNetworkData ind in ModManager.clientSync.syncData.items.Values.ToList()) {
                 if(ind.holdingStates == null) continue;
                 try {
                     if(ind.holdingStates.First(state => state.holderNetworkId == id && state.holderType == holderType) != null) {
@@ -742,7 +742,7 @@ namespace AMP.Network.Client {
             List<Item> unsynced_items = Item.allActive.Where(item => syncData.items.All(entry => !item.Equals(entry.Value.clientsideItem))).ToList();
             foreach(Item item in unsynced_items) {
                 //float range = SyncFunc.getCloneDistance(item.itemId);
-                foreach(ItemNetworkData ind in syncData.items.Values) {
+                foreach(ItemNetworkData ind in known_items) {
                     if(item.transform.position.CloserThan(ind.position, 5f)) {
                         i++;
                         try {

--- a/Network/Packets/Implementation/PrepareLevelChangePacket.cs
+++ b/Network/Packets/Implementation/PrepareLevelChangePacket.cs
@@ -6,6 +6,7 @@ using Netamite.Network.Packet;
 using Netamite.Network.Packet.Attributes;
 using Netamite.Server.Definition;
 using System;
+using System.Linq;
 using ThunderRoad;
 using UnityEngine;
 using static ThunderRoad.TextData;
@@ -29,13 +30,13 @@ namespace AMP.Network.Packets.Implementation {
             ModManager.clientInstance.allowTransmission = false;
 
             Dispatcher.Enqueue(() => {
-                foreach(PlayerNetworkData playerSync in ModManager.clientSync.syncData.players.Values) { // Will despawn all player creatures and respawn them after level has changed
+                foreach(PlayerNetworkData playerSync in ModManager.clientSync.syncData.players.Values.ToList()) { // Will despawn all player creatures and respawn them after level has changed
                     if(playerSync.creature == null) continue;
 
                     playerSync.Despawn();
                 }
 
-                foreach(ItemNetworkData item in ModManager.clientSync.syncData.items.Values) {
+                foreach(ItemNetworkData item in ModManager.clientSync.syncData.items.Values.ToList()) {
                     if(item.clientsideItem != null) item.clientsideItem.DisallowDespawn = false;
 
                     item.networkItem?.UnregisterEvents();
@@ -45,7 +46,7 @@ namespace AMP.Network.Packets.Implementation {
                 ModManager.clientSync.syncData.owningItems.Clear();
 
 
-                foreach(CreatureNetworkData creature in ModManager.clientSync.syncData.creatures.Values) {
+                foreach(CreatureNetworkData creature in ModManager.clientSync.syncData.creatures.Values.ToList()) {
                     creature.networkCreature?.UnregisterEvents();
                     GameObject.Destroy(creature.networkCreature);
                 }
@@ -53,7 +54,7 @@ namespace AMP.Network.Packets.Implementation {
                 ModManager.clientSync.syncData.owningCreatures.Clear();
 
 
-                foreach(EntityNetworkData entity in ModManager.clientSync.syncData.entities.Values) {
+                foreach(EntityNetworkData entity in ModManager.clientSync.syncData.entities.Values.ToList()) {
                     //entity.networkEntity?.UnregisterEvents();
                     GameObject.Destroy(entity.networkEntity);
                 }


### PR DESCRIPTION
- ClientSync.Stop(): All iterations now use ToList() to prevent issues when LeavePlayer modifies the collection
- ClientSync.TryRespawningPlayers(): Safe iteration over players
- ClientSync.SendMovedCreatures/Entities(): Safe iteration during network sync
- ClientSync.WaitForCreature(): Safe iteration when checking existing creatures
- ClientSync.EquipItemsForCreature(): Safe iteration over items
- ClientSync.CleanCollidingItems(): Reuse existing snapshot instead of iterating twice
- PrepareLevelChangePacket: All cleanup iterations now use ToList()

This prevents potential crashes, skipped elements, or inconsistent state when collections are modified during iteration (e.g., when disconnecting or changing levels).